### PR TITLE
Switch order of lat-lon in GeoJSON output.

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 				flon, _ := strconv.ParseFloat(lat, 64)
 				geom := Geometry{
 					Type:        "Point",
-					Coordinates: []float64{flon, flat},
+					Coordinates: []float64{flat, flon},
 				}
 
 				g := GeoJSON{


### PR DESCRIPTION
According to RFC7946, the GeoJSON spec, points must be X,Y, or Lon,Lat.
The implementation here had them the wrong way around in the resulting
array.

This commit fixes that.

> A.1.  Points
>
>   Point coordinates are in x, y order (easting, northing for projected
>   coordinates, longitude, and latitude for geographic coordinates):-

from: https://tools.ietf.org/html/rfc7946#appendix-A